### PR TITLE
fix(ios): merge params on url and in param object

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -256,9 +256,12 @@ public class CAPHttpPlugin: CAPPlugin {
   
   func setUrlQuery(_ url: inout URL, _ params: [String:String]) {
     var cmps = URLComponents(url: url, resolvingAgainstBaseURL: true)
-    cmps!.queryItems = params.map({ (key, value) -> URLQueryItem in
+    if cmps?.queryItems == nil {
+      cmps?.queryItems = []
+    }
+    cmps!.queryItems?.append(contentsOf: params.map({ (key, value) -> URLQueryItem in
       return URLQueryItem(name: key, value: value)
-    })
+    }))
     url = cmps!.url!
   }
   


### PR DESCRIPTION
Currently in iOS, any query params that are set on the url are overwritten with the params from the request options:
```js
await Http.request({
  method: 'GET',
  url: 'https://example.com?inlineParam=inlineValue',
  params: {
    objectParam: 'objectValue'
  }
});
```
becomes `https://example.com?objectParam=objectValue`.

This will append any params set on the request to the `params` object in the options. So the url becomes `https://example.com?inlineParam=inlineValue&objectParam=objectValue`.