### PR TITLE
fix(android): get http error data from error stream

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -368,7 +368,8 @@ public class Http extends Plugin {
     ret.put("status", statusCode);
     ret.put("headers", makeResponseHeaders(conn));
 
-    InputStream stream = conn.getInputStream();
+    InputStream errorStream = conn.getErrorStream();
+    InputStream stream = (errorStream != null ? errorStream : conn.getInputStream());
 
     BufferedReader in = new BufferedReader(new InputStreamReader(stream));
     StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
This will return HTTP error data from the server so the app can handle the errors.
Ideally the plugin could actually throw an error to the app, but currently Capacitor does not support sending a JSObject with an error or reject.