### PR TITLE
fix(android): automatically set cookies from requests

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/WebkitCookieManagerProxy.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/WebkitCookieManagerProxy.java
@@ -1,0 +1,96 @@
+package com.getcapacitor.plugin.http;
+
+import android.webkit.ValueCallback;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.CookieStore;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class WebkitCookieManagerProxy extends CookieManager
+{
+    private android.webkit.CookieManager webkitCookieManager;
+
+    public String getCookie(String url) {
+        return this.webkitCookieManager.getCookie(url);
+    }
+
+    public void setCookie(String url, String value) {
+        this.webkitCookieManager.setCookie(url, value);
+        this.webkitCookieManager.flush();
+    }
+
+    public void flush() {
+        this.webkitCookieManager.flush();
+    }
+
+    public void removeAllCookies(ValueCallback<Boolean> callback) {
+        this.webkitCookieManager.removeAllCookies(callback);
+    }
+
+    public WebkitCookieManagerProxy()
+    {
+        this(null, null);
+    }
+
+    public WebkitCookieManagerProxy(CookieStore store, CookiePolicy cookiePolicy)
+    {
+        super(null, cookiePolicy);
+
+        this.webkitCookieManager = android.webkit.CookieManager.getInstance();
+    }
+
+    @Override
+    public void put(URI uri, Map<String, List<String>> responseHeaders) throws IOException
+    {
+        // make sure our args are valid
+        if ((uri == null) || (responseHeaders == null)) return;
+
+        // save our url once
+        String url = uri.toString();
+
+        // go over the headers
+        for (String headerKey : responseHeaders.keySet())
+        {
+            // ignore headers which aren't cookie related
+            if ((headerKey == null) || !(headerKey.equalsIgnoreCase("Set-Cookie2") || headerKey.equalsIgnoreCase("Set-Cookie"))) continue;
+
+            // process each of the headers
+            for (String headerValue : responseHeaders.get(headerKey))
+            {
+                this.setCookie(url, headerValue);
+            }
+        }
+    }
+
+    @Override
+    public Map<String, List<String>> get(URI uri, Map<String, List<String>> requestHeaders) throws IOException
+    {
+        // make sure our args are valid
+        if ((uri == null) || (requestHeaders == null)) throw new IllegalArgumentException("Argument is null");
+
+        // save our url once
+        String url = uri.toString();
+
+        // prepare our response
+        Map<String, List<String>> res = new java.util.HashMap<String, List<String>>();
+
+        // get the cookie
+        String cookie = this.getCookie(url);
+
+        // return it
+        if (cookie != null) res.put("Cookie", Arrays.asList(cookie));
+        return res;
+    }
+
+    @Override
+    public CookieStore getCookieStore()
+    {
+        // we don't want anyone to work with this cookie store directly
+        throw new UnsupportedOperationException();
+    }
+}

--- a/android/src/main/java/com/getcapacitor/plugin/http/WebkitCookieManagerProxy.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/WebkitCookieManagerProxy.java
@@ -11,86 +11,83 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class WebkitCookieManagerProxy extends CookieManager
-{
-    private android.webkit.CookieManager webkitCookieManager;
+public class WebkitCookieManagerProxy extends CookieManager {
+  private android.webkit.CookieManager webkitCookieManager;
 
-    public String getCookie(String url) {
-        return this.webkitCookieManager.getCookie(url);
+  public String getCookie(String url) {
+    return this.webkitCookieManager.getCookie(url);
+  }
+
+  public void setCookie(String url, String value) {
+    this.webkitCookieManager.setCookie(url, value);
+    this.webkitCookieManager.flush();
+  }
+
+  public void flush() {
+    this.webkitCookieManager.flush();
+  }
+
+  public void removeAllCookies(ValueCallback<Boolean> callback) {
+    this.webkitCookieManager.removeAllCookies(callback);
+  }
+
+  public WebkitCookieManagerProxy() {
+    this(null, null);
+  }
+
+  public WebkitCookieManagerProxy(CookieStore store, CookiePolicy cookiePolicy) {
+    super(null, cookiePolicy);
+
+    this.webkitCookieManager = android.webkit.CookieManager.getInstance();
+  }
+
+  @Override
+  public void put(URI uri, Map<String, List<String>> responseHeaders) throws IOException {
+    // make sure our args are valid
+    if ((uri == null) || (responseHeaders == null))
+      return;
+
+    // save our url once
+    String url = uri.toString();
+
+    // go over the headers
+    for (String headerKey : responseHeaders.keySet()) {
+      // ignore headers which aren't cookie related
+      if ((headerKey == null)
+          || !(headerKey.equalsIgnoreCase("Set-Cookie2") || headerKey.equalsIgnoreCase("Set-Cookie")))
+        continue;
+
+      // process each of the headers
+      for (String headerValue : responseHeaders.get(headerKey)) {
+        this.setCookie(url, headerValue);
+      }
     }
+  }
 
-    public void setCookie(String url, String value) {
-        this.webkitCookieManager.setCookie(url, value);
-        this.webkitCookieManager.flush();
-    }
+  @Override
+  public Map<String, List<String>> get(URI uri, Map<String, List<String>> requestHeaders) throws IOException {
+    // make sure our args are valid
+    if ((uri == null) || (requestHeaders == null))
+      throw new IllegalArgumentException("Argument is null");
 
-    public void flush() {
-        this.webkitCookieManager.flush();
-    }
+    // save our url once
+    String url = uri.toString();
 
-    public void removeAllCookies(ValueCallback<Boolean> callback) {
-        this.webkitCookieManager.removeAllCookies(callback);
-    }
+    // prepare our response
+    Map<String, List<String>> res = new java.util.HashMap<String, List<String>>();
 
-    public WebkitCookieManagerProxy()
-    {
-        this(null, null);
-    }
+    // get the cookie
+    String cookie = this.getCookie(url);
 
-    public WebkitCookieManagerProxy(CookieStore store, CookiePolicy cookiePolicy)
-    {
-        super(null, cookiePolicy);
+    // return it
+    if (cookie != null)
+      res.put("Cookie", Arrays.asList(cookie));
+    return res;
+  }
 
-        this.webkitCookieManager = android.webkit.CookieManager.getInstance();
-    }
-
-    @Override
-    public void put(URI uri, Map<String, List<String>> responseHeaders) throws IOException
-    {
-        // make sure our args are valid
-        if ((uri == null) || (responseHeaders == null)) return;
-
-        // save our url once
-        String url = uri.toString();
-
-        // go over the headers
-        for (String headerKey : responseHeaders.keySet())
-        {
-            // ignore headers which aren't cookie related
-            if ((headerKey == null) || !(headerKey.equalsIgnoreCase("Set-Cookie2") || headerKey.equalsIgnoreCase("Set-Cookie"))) continue;
-
-            // process each of the headers
-            for (String headerValue : responseHeaders.get(headerKey))
-            {
-                this.setCookie(url, headerValue);
-            }
-        }
-    }
-
-    @Override
-    public Map<String, List<String>> get(URI uri, Map<String, List<String>> requestHeaders) throws IOException
-    {
-        // make sure our args are valid
-        if ((uri == null) || (requestHeaders == null)) throw new IllegalArgumentException("Argument is null");
-
-        // save our url once
-        String url = uri.toString();
-
-        // prepare our response
-        Map<String, List<String>> res = new java.util.HashMap<String, List<String>>();
-
-        // get the cookie
-        String cookie = this.getCookie(url);
-
-        // return it
-        if (cookie != null) res.put("Cookie", Arrays.asList(cookie));
-        return res;
-    }
-
-    @Override
-    public CookieStore getCookieStore()
-    {
-        // we don't want anyone to work with this cookie store directly
-        throw new UnsupportedOperationException();
-    }
+  @Override
+  public CookieStore getCookieStore() {
+    // we don't want anyone to work with this cookie store directly
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
This allows cookies to sync between `android.webkit.CookieManager` and `java.net.CookieHandler` so that cookies can automatically be set from requests. Requests made using `HTTPURLConnection` automatically set cookies using `java.net.CookieHandler`, so this is required to set those to the `android.webkit.CookieManager` automatically. This is based on [this implementation](https://stackoverflow.com/a/18070681).

There maybe be a more elegant option for automatically setting the cookies, but it doesn't appear possible when using `HTTPURLConnection` with `android.webkit.CookieManager` without some additional work.
